### PR TITLE
Fix bug with how files and strings are terminated

### DIFF
--- a/packages/ash/assembly/__tests__/echo.spec.ts
+++ b/packages/ash/assembly/__tests__/echo.spec.ts
@@ -17,12 +17,12 @@ describe("echo", (): void => {
     echo(CommandLine.all())
     let str = Hello + " " + World + "\n";
     let stdoutStr = readString(stdout)
-    expect<u32>(Console.stdout.tell()).toBe(str.lengthUTF8, "Two extra characters for space and \\n")
+    expect<u32>(Console.stdout.tell()).toBe(str.lengthUTF8)
     Console.stdout.reset();
     expect<string>(readString(Console.stdout)).toBe(Hello + " " + World + "\n")
     Console.stdout.reset();
     expect<string>(readString(Console.stdout)).toBe(stdoutStr);
-  })
+  });
 
   it("should print no newline with -n", () => {
     CommandLine.push("-n")
@@ -30,7 +30,7 @@ describe("echo", (): void => {
     CommandLine.push(World)
     echo(CommandLine.all())
     let str = Hello + " " + World;
-    expect<u32>(Console.stdout.tell()).toBe(str.lengthUTF8 + 1, "Two extra characters for space and \\n")
+    expect<u32>(Console.stdout.tell()).toBe(str.lengthUTF8)
     Console.stdout.reset();
     expect<string>(Console.stdout.readString().result).toBe(str)
     Console.stdout.reset();

--- a/packages/assemblyscript/assembly/wasa/mock/fs/fs.ts
+++ b/packages/assemblyscript/assembly/wasa/mock/fs/fs.ts
@@ -94,7 +94,7 @@ export class FileDescriptor {
                 break;
             }
             case Wasi.whence.END: {
-                newOffset = <usize>(this.length - <u64>Math.abs(<f64>offset));
+                newOffset = <usize>(this.size - <u64>Math.abs(<f64>offset));
                 break;
             }
             case Wasi.whence.SET: {

--- a/packages/assemblyscript/assembly/wasa/mock/utils/index.ts
+++ b/packages/assemblyscript/assembly/wasa/mock/utils/index.ts
@@ -1,33 +1,41 @@
 
-const newLine: u8 = 10;
 
 export class StringUtils {
-  static isNewLine(ptr: usize): boolean {
-    return load<u8>(ptr) == newLine;
-  }
+    static readonly NUL: u8 = 0;
+    static readonly EOT: u8 = 4;
+    static readonly LF: u8 = 10;
 
-  static fromCString(cstring: usize, max: usize = 4096): string | null {
-    let size: usize = 0;
-    while (load<u8>(cstring + size) != 0 && size < max) {
-      size++;
+    static isNewLine(ptr: usize): boolean {
+        return load<u8>(ptr) == this.LF;
     }
-    if (size >= max && load<u8>(cstring + size) != 0) {
-      return null;
-    }
-    return String.fromUTF8(cstring, size);
-  }
 
-  static fromCStringTilNewLine(cstring: usize, max: usize): string | null {
-    let size: usize = 0;
-    while (load<u8>(cstring + size) != 0 && size < max) {
-      size++;
-      if (this.isNewLine(cstring + size - 1)) {
-        break;
-      }
+    private static terminates(ptr: usize): bool {
+        let char: u8 = load<u8>(ptr);
+        return char == this.NUL || char == this.EOT
     }
-    if (size >= max && load<u8>(cstring + size) != 0) {
-      return null;
+
+    static fromCString(cstring: usize, max: usize = 4096): string | null {
+        let size: usize = 0;
+        while (!this.terminates(cstring + size) && size < max - 1) {
+            size++;
+        }
+        if (size == 0) {
+            return null
+        }
+        return String.fromUTF8(cstring, size);
     }
-    return String.fromUTF8(cstring, size);
-  }
+
+    static fromCStringTilNewLine(cstring: usize, max: usize): string | null {
+        let size: usize = 0;
+        while (!this.terminates(cstring + size) && size < max - 1) {
+            size++;
+            if (this.isNewLine(cstring + size - 1)) {
+                break;
+            }
+        }
+        if (size == 0) {
+            return null
+        }
+        return String.fromUTF8(cstring, size);
+    }
 }

--- a/types/wasa/index.d.ts
+++ b/types/wasa/index.d.ts
@@ -84,6 +84,9 @@ declare class FileDescriptor {
   file: File | null;
   fd: u32;
   offset: u32;
+  /**
+   * Number of bytes written to the file.
+   */
   size: usize;
 
   /**

--- a/types/wasa/index.d.ts
+++ b/types/wasa/index.d.ts
@@ -84,6 +84,7 @@ declare class FileDescriptor {
   file: File | null;
   fd: u32;
   offset: u32;
+  size: usize;
 
   /**
    * Write an array of bytes to a file;
@@ -152,7 +153,7 @@ declare class DirectoryDescriptor extends FileDescriptor {
   /**
    * Returns list of names of entries in the directory.
    */
-  listDir(): string[];
+  listDir(): DirectoryEntry[];
 
   /**Path of parent directory */
   parent: string;
@@ -342,6 +343,7 @@ declare class fs {
 declare class DirectoryEntry {
   path: string;
   type: Wasi.filetype;
+  size: usize;
 }
 
 /**


### PR DESCRIPTION
Now readString and readLine will return null if reading a terminating char like EOF.

Also a file keeps track of it's size and updates the EOF character at the end.