### PR TITLE
Actually fixes the off by one error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1807,22 +1807,36 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "as-pect": {
-      "version": "github:jtenner/as-pect#5ca03818000a6649dfe8b43fe8c3f3951d9d26fd",
+      "version": "github:jtenner/as-pect#5d8ef1559ff3841973860ee82c425a552b94b335",
       "from": "github:jtenner/as-pect",
       "dev": true,
       "requires": {
         "assemblyscript": "github:assemblyscript/assemblyscript",
         "chalk": "^2.4.2",
-        "glob": "^7.1.3",
-        "mathjs": "^5.9.0",
+        "glob": "^7.1.4",
+        "mathjs": "^5.10.0",
         "ts-node": "^8.1.0",
-        "yargs-parser": "^13.0.0"
+        "yargs-parser": "^13.1.0"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "yargs-parser": {
-          "version": "13.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
-          "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.0.tgz",
+          "integrity": "sha512-Yq+32PrijHRri0vVKQEm+ys8mbqWjLiwQkMFNXEENutzLPP0bE4Lcd4iA3OQY5HF+GD3xXxf0MEHb8E4/SA3AA==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -3263,9 +3277,9 @@
       }
     },
     "decimal.js": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.1.1.tgz",
-      "integrity": "sha512-vEEgyk1fWVEnv7lPjkNedAIjzxQDue5Iw4FeX4UkNUDSVyD/jZTD0Bw2kAO7k6iyyJRAhM9oxxI0D1ET6k0Mmg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==",
       "dev": true
     },
     "decode-uri-component": {
@@ -7126,13 +7140,13 @@
       }
     },
     "mathjs": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-5.9.0.tgz",
-      "integrity": "sha512-f1xmJklkTCr48y023cFy/ZSoVzOfgHp1gutvebi/Vv5RLly6j8G9T2/XHkfXewZKcwPDbhBkFEYljaCjudxulQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-5.10.0.tgz",
+      "integrity": "sha512-AWvw1VRZv/37TlHGyAdUPc8U59jHE1cT4jfmM5D7Z18uUaGPqpG59Ia5VvQosxvO71KNBxXAImfxTwEt+6fA3A==",
       "dev": true,
       "requires": {
         "complex.js": "2.0.11",
-        "decimal.js": "10.1.1",
+        "decimal.js": "10.2.0",
         "escape-latex": "1.2.0",
         "fraction.js": "4.0.12",
         "javascript-natural-sort": "0.7.1",

--- a/packages/ash/assembly/__tests__/cat.spec.ts
+++ b/packages/ash/assembly/__tests__/cat.spec.ts
@@ -17,7 +17,7 @@ describe("cat", (): void => {
         CommandLine.push("/test")
         cat(CommandLine.all())
         let str = Hello_World + "\n";
-        expect<u32>(Console.stdout.tell()).toBe(str.lengthUTF8, "Two extra characters for space and \\n")
+        expect<u32>(Console.stdout.tell()).toBe(str.lengthUTF8 - 1, "String doesn't have a terminating NUL")
         fs.reset(Console.stdout.fd)
         expect<string>(fs.readString(Console.stdout.fd).result).toBe(Hello + " " + World + "\n")
         Console.stdout.reset()
@@ -35,7 +35,7 @@ describe("cat", (): void => {
         CommandLine.push("/test")
         CommandLine.push("/numbers")
         cat(CommandLine.all())
-        expect<usize>(Console.stdout.tell()).toBeGreaterThan(Hello_World.lengthUTF8 + 1);
+        expect<usize>(Console.stdout.tell()).toBeGreaterThan(Hello_World.lengthUTF8 - 1);
     });
 
 })

--- a/packages/ash/assembly/__tests__/echo.spec.ts
+++ b/packages/ash/assembly/__tests__/echo.spec.ts
@@ -17,7 +17,7 @@ describe("echo", (): void => {
     echo(CommandLine.all())
     let str = Hello + " " + World + "\n";
     let stdoutStr = readString(stdout)
-    expect<u32>(Console.stdout.tell()).toBe(str.lengthUTF8)
+    expect<u32>(Console.stdout.tell()).toBe(str.lengthUTF8 - 1, "No NUL character at the end of the string")
     Console.stdout.reset();
     expect<string>(readString(Console.stdout)).toBe(Hello + " " + World + "\n")
     Console.stdout.reset();
@@ -30,7 +30,7 @@ describe("echo", (): void => {
     CommandLine.push(World)
     echo(CommandLine.all())
     let str = Hello + " " + World;
-    expect<u32>(Console.stdout.tell()).toBe(str.lengthUTF8)
+    expect<u32>(Console.stdout.tell()).toBe(str.lengthUTF8 - 1, "No NUL character at the end of the string")
     Console.stdout.reset();
     expect<string>(Console.stdout.readString().result).toBe(str)
     Console.stdout.reset();

--- a/packages/ash/assembly/__tests__/fixtures.ts
+++ b/packages/ash/assembly/__tests__/fixtures.ts
@@ -7,18 +7,23 @@ export var stdin: FileDescriptor;
 export var stdout: FileDescriptor;
 export var stderr: FileDescriptor;
 
-
 beforeAll(() => {
-    addJSONtoFS(fs_str);
+    init();
+})
+
+
+export function init(): void {
     fs.init();
+    addJSONtoFS(fs_str);
+    log<string>("added FS")
     Console.stdout;
     Console.stdin;
     Console.stderr;
     stdin = openStdin();
     stdout = openStdout();
     stderr = openStderr();
-})
 
+}
 export function openStdin(): FileDescriptor {
     return openFile("/dev/fd/0");
 }

--- a/packages/assemblyscript/assembly/__tests__/wasa.include.ts
+++ b/packages/assemblyscript/assembly/__tests__/wasa.include.ts
@@ -1,6 +1,7 @@
 
 import { Console, fs, Process, CommandLine, fd, FileDescriptor } from '../wasa/mock/index';
 import { Wasi } from "../wasi";
+import { WasiResult } from '../wasa/index';
 
 /** This file is included with tests so that the default globals are set up properly. */
 beforeAll(() => {

--- a/packages/assemblyscript/assembly/__tests__/wasa.spec.ts
+++ b/packages/assemblyscript/assembly/__tests__/wasa.spec.ts
@@ -32,7 +32,7 @@ describe("Console", (): void => {
     );
 
     expect<u32>(Console.stdout.offset).toBe(
-      jsonStr.lengthUTF8 + 1, //Plus nil
+      jsonStr.lengthUTF8, //No NUL character at the end of the string
       "length of string + \\n"
     );
     // expect<u32>(stdout.offset).toBe(0); //"new line addded"
@@ -113,7 +113,7 @@ describe("write", (): void => {
     expect<usize>(file.size).toBe(0);
     let str = "hello world";
     expect<Wasi.errno>(file.writeString("hello world")).toBe(Wasi.errno.SUCCESS)
-    expect<usize>(file.size).toBe(str.lengthUTF8);
+    expect<usize>(file.size).toBe(str.lengthUTF8 - 1, "No NUL character at the end of the string")
   });
 
   it("should not update size if offset is less than size", (): void => {
@@ -121,6 +121,6 @@ describe("write", (): void => {
     expect<Wasi.errno>(file.writeString("hello world")).toBe(Wasi.errno.SUCCESS)
     file.reset();
     expect<Wasi.errno>(file.writeString("HELLO")).toBe(Wasi.errno.SUCCESS)
-    expect<usize>(file.size).toBe(str.lengthUTF8);
+    expect<usize>(file.size).toBe(str.lengthUTF8 - 1, "No NUL character at the end of the string")
   })
 })

--- a/packages/assemblyscript/assembly/wasa/index.ts
+++ b/packages/assemblyscript/assembly/wasa/index.ts
@@ -11,7 +11,8 @@ export class Ref<T>{
     constructor(public val: T) { }
 }
 
-
+//@ts-ignore
+@global
 /**
  * Helper class for dealing with errors.
  */

--- a/packages/assemblyscript/assembly/wasa/mock/utils/index.ts
+++ b/packages/assemblyscript/assembly/wasa/mock/utils/index.ts
@@ -28,14 +28,14 @@ export class StringUtils {
     static fromCStringTilNewLine(cstring: usize, max: usize): string | null {
         let size: usize = 0;
         while (!this.terminates(cstring + size) && size < max - 1) {
-            size++;
-            if (this.isNewLine(cstring + size - 1)) {
+            if (this.isNewLine(cstring + size)) {
                 break;
             }
+            size++;
         }
         if (size == 0) {
             return null
         }
-        return String.fromUTF8(cstring, size);
+        return String.fromUTF8(cstring, size + 1);
     }
 }


### PR DESCRIPTION
`String.lengthUTF8` included the NUL character at the end.  This meant that it was also written to the file and the offset was updated one too fare with reads.  